### PR TITLE
Fix for Symlink files

### DIFF
--- a/denops/@ddu-sources/file.ts
+++ b/denops/@ddu-sources/file.ts
@@ -37,7 +37,14 @@ export class Source extends BaseSource<Params> {
           try {
             for await (const entry of Deno.readDir(root)) {
               const path = join(root, entry.name);
-              const stat = await Deno.stat(path);
+              const stat = await (async () => {
+                let ret = await Deno.lstat(path);
+                if (ret.isSymlink) {
+                  ret = await Deno.stat(path);
+                  ret.isSymlink = true;
+                }
+                return ret;
+              })();
               items.push({
                 word: relative(dir, path) + (stat.isDirectory ? "/" : ""),
                 action: {


### PR DESCRIPTION
Now, `ActionData.isLink` is `false` if the path is a symlink because `Deno.stat()` follows symlinks and returns file information.

`Deno.lstat()` returns whether the path is a symlink. But if the path is a symlink, it dose not return file information.

Therefore, Using both functions, we can get file information and whether it is a symlink.