### PR TITLE
Add params for ignoreing directories

### DIFF
--- a/denops/@ddu-sources/file.ts
+++ b/denops/@ddu-sources/file.ts
@@ -20,6 +20,7 @@ import { relative } from "jsr:@std/path@~1.0.2/relative";
 
 type Params = {
   "new": boolean;
+  "ignoredDirectories": boolean;
 };
 
 export class Source extends BaseSource<Params> {
@@ -57,6 +58,8 @@ export class Source extends BaseSource<Params> {
 
               const stat = await safeStat(path);
               if (!stat) {
+                continue;
+              } else if (args.sourceParams.ignoredDirectories && stat.isDirectory){
                 continue;
               }
 
@@ -174,6 +177,7 @@ export class Source extends BaseSource<Params> {
   override params(): Params {
     return {
       "new": false,
+      "ignoredDirectories": false
     };
   }
 }

--- a/denops/@ddu-sources/file.ts
+++ b/denops/@ddu-sources/file.ts
@@ -59,7 +59,9 @@ export class Source extends BaseSource<Params> {
               const stat = await safeStat(path);
               if (!stat) {
                 continue;
-              } else if (args.sourceParams.ignoredDirectories && stat.isDirectory){
+              } else if (
+                args.sourceParams.ignoredDirectories && stat.isDirectory
+              ) {
                 continue;
               }
 
@@ -177,7 +179,7 @@ export class Source extends BaseSource<Params> {
   override params(): Params {
     return {
       "new": false,
-      "ignoredDirectories": false
+      "ignoredDirectories": false,
     };
   }
 }

--- a/doc/ddu-source-file.txt
+++ b/doc/ddu-source-file.txt
@@ -48,6 +48,11 @@ new		(boolean)
 
 		Default: v:false
 
+                                    *ddu-source-file-param-ignoredDirectories*
+ignoredDirectories	(boolean)
+		ignore directories.
+
+		Default: v:false
 
 ==============================================================================
 FREQUENTLY ASKED QUESTIONS (FAQ)		*ddu-source-file-faq*


### PR DESCRIPTION
I would like that it ignore directory.
Using `ddu-ui-ff` as ui extension, I started to create extensions for only directory to gather and to preview or restart `ddu#start()`.
I will leave it to you to decide whether to merge them.

# What I did

Add `ignoredDirectories` in `sourceParams`
When `ignoredDirectories` is true, don't gather directory.
